### PR TITLE
Fixed a bug that would cause events to fire at the wrong time since the ...

### DIFF
--- a/scrollMonitor.js
+++ b/scrollMonitor.js
@@ -106,10 +106,10 @@
 
 		this.locked = false;
 
-		var wasInViewport = this.isInViewport;
-		var wasFullyInViewport = this.isFullyInViewport;
-		var wasAboveViewport = this.isAboveViewport;
-		var wasBelowViewport = this.isBelowViewport;
+		var wasInViewport;
+		var wasFullyInViewport;
+		var wasAboveViewport;
+		var wasBelowViewport;
 
 		var listenerToTriggerListI;
 		var listener;
@@ -219,6 +219,11 @@
 
 		this.recalculateLocation();
 		this.update();
+
+		wasInViewport = this.isInViewport;
+		wasFullyInViewport = this.isFullyInViewport;
+		wasAboveViewport = this.isAboveViewport;
+		wasBelowViewport = this.isBelowViewport;
 	}
 
 	ElementWatcher.prototype = {


### PR DESCRIPTION
...initial value of some variables was wrong.

I was doing something like `elementWatcher.one('enterViewport', function() {});` and when I scrolled a tiny bit it would fire that event for all elements even if they weren't on the page. I tracked it down to all of the 'was' variables being set to undefined when initially setup which causes the callbacks for when you skip past an element to get triggered.

This pull request makes all of the 'was' variables get set after positions and everything have been calculated.
