### PR TITLE
Make scrollMonitor instance based

### DIFF
--- a/scrollMonitor.js
+++ b/scrollMonitor.js
@@ -55,6 +55,8 @@
 
 		this.$viewport.on('scroll', scrollMonitorListener);
 		this.$viewport.on('resize', debouncedRecalcuateAndTrigger);
+
+		this.calculateViewport();
 	}
 
 	ScrollMonitor.prototype = {
@@ -334,8 +336,6 @@
 	exports.viewportBottom = scrollMonitor.viewportBottom;
 	exports.documentHeight = scrollMonitor.documentHeight;
 	exports.viewportHeight = scrollMonitor.viewportHeight;
-
-	scrollMonitor.calculateViewport();
 
 	exports.beget = exports.create = function( element, offsets ) {
 		return scrollMonitor.create(element, offsets);


### PR DESCRIPTION
Hello @sakabako !  Before I say anything else let me write that your scrollMonitor is most excellent and I greatly appreciate the work you've done on it.  It works just as advertised and it works very nicely :)

This pull request I've opened revises the internal architecture of scrollMonitor to be instance based while not modifying the external API.  Most of the work I did was re-arranging code and revising references according to the new location of code.

This PR was created in preparation of a second PR that depended on these revisions.  If you like the changes in this PR I'll open a second PR with the other changes I've added.  

(If you want to sneak a peak at them they're in this branch in my fork https://github.com/hswolff/scrollMonitor/tree/allow-multiple-containers .  The summary is that I needed the ability to use scrollMonitor in a container that wasn't the document, this other branch adds that capability.)
