### PR TITLE
fix jquery var name to $

### DIFF
--- a/scrollMonitor.js
+++ b/scrollMonitor.js
@@ -2,7 +2,7 @@
 	if (typeof define !== 'undefined' && define.amd) {
 		define(['jquery'], factory);
 	} else if (typeof module !== 'undefined' && module.exports) {
-		var jQuery = require('jquery');
+		var $ = require('jquery');
 		module.exports = factory( $ );
 	} else {
 		window.scrollMonitor = factory( $ );


### PR DESCRIPTION
The `jquery` variable is useless, it should be `$`.
