### PR TITLE
Add "main" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	"scroll",
 	"dom"
   ],
+  "main": "./scrollMonitor.js",
   "dependencies" : {
 	"jquery"   :  ">= 1.2.6"
   }


### PR DESCRIPTION
Not written by me because @oroce had already done it, merely making the PR because there is no reason for this not to be in the main module.

To use this within node (and browserify) an entrypoint needs to be defined in the package.json. This makes it so you can, in node, do this:

```
var scrollmontior = require('scrollmonitor');

// use it
```

Thanks!
