### PR TITLE
Swap enter/exit viewport methods on README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Sometimes you want to change the element you're watching, but want to continue w
 var watcher = scrollMonitor.create( $element );
 watcher.lock(); // ensure that we're always watching the place the element originally was
 
-watcher.exitViewport(function() {
+watcher.enterViewport(function() {
     $element.addClass('fixed');
 });
-watcher.enterViewport(function() {
+watcher.exitViewport(function() {
     $element.removeClass('fixed');
 });
 ```


### PR DESCRIPTION
I've just read the README and it's very complete. One minor issue though: on the Locking section the listeners (enterViewport / exitViewport) was swapped. 
