### PR TITLE
add scrollMonitor.destroyAll() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ scrollMonitor.create( element, -200 )
 * `scrollMonitor.create( watchItem, offsets )` - Returns a new watcher. `watchItem` is a DOM element, jQuery object, NodeList, CSS selector, object with .top and .bottom, or a number.
 * `scrollMonitor.update()` - update and trigger all watchers.
 * `scrollMonitor.recalculateLocations()` - recalculate the location of all unlocked watchers and trigger if needed.
+* `scrollMonitor.destroyAll()` - destroy all watchers.
 
 ### Properties
 * `scrollMonitor.viewportTop` - distance from the top of the document to the top of the viewport.
 * `scrollMonitor.viewportBottom` - distance from the top of the document to the bottom of the viewport.
 * `scrollMonitor.viewportHeight` - height of the viewport.
 * `scrollMonitor.documentHeight` - height of the document.
-

--- a/scrollMonitor.js
+++ b/scrollMonitor.js
@@ -370,6 +370,14 @@
 		exports.documentHeight = 0;
 		exports.update();
 	};
+	exports.destroyAll = function() {
+		for (var w = 0, x = watchers.length; w < x; w++) {
+			for (var i = 0, j = eventTypes.length; i < j; i++) {
+				watchers[w].callbacks[eventTypes[i]].length = 0;
+			}
+		}
+		watchers.length = 0;
+	};
 
 	return exports;
 });


### PR DESCRIPTION
Hi,
We're using scrollMonitor in a single-page app which replaces a large number of elements during search or navigation. This `destroyAll()` function has been useful to cleanup between page transitions.

I tried to `npm install` to run your tests, but the dependencies are so old, the karma launcher will no longer compile.

hth.
j