### PR TITLE
Changed jQuery check to global not $ alias

### DIFF
--- a/scrollMonitor.js
+++ b/scrollMonitor.js
@@ -327,7 +327,7 @@
 		calculateViewport();
 	} catch (e) {
 		try {
-			window.$(calculateViewport);
+			window.jQuery(calculateViewport);
 		} catch (e) {
 			throw new Error('If you must put scrollMonitor in the <head>, you must use jQuery.');
 		}


### PR DESCRIPTION
- refined the jQuery check to use the global jQuery object and not the $ alias.
  -- this handles the situation where jQuery is loaded, but the $ alias is not assigned.
