### PR TITLE
Fixed Demo Files

### DIFF
--- a/demos/fixed.html
+++ b/demos/fixed.html
@@ -36,7 +36,7 @@
 	<span class="three">Three!</span>
 </div>
 <a href="https://github.com/sakabako/scrollMonitor"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
-<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script src="../scrollMonitor.js"></script>
 <script type="text/javascript">
 

--- a/demos/list.html
+++ b/demos/list.html
@@ -43,7 +43,7 @@
 <body>
 <div id="target"></div>
 <a href="https://github.com/sakabako/scrollMonitor"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
-<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script src="../scrollMonitor.js"></script>
 <script type="text/javascript">
 //requirejs(['../scrollMonitor'], function( scrollMonitor ) {

--- a/demos/scoreboard.html
+++ b/demos/scoreboard.html
@@ -58,7 +58,7 @@
     </div>
 </div>
 <a href="https://github.com/sakabako/scrollMonitor"><img style="position: fixed; top: 0; right: 0; border: 0; z-index:1000000" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
-<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script src="../scrollMonitor.js"></script>
 <script type="text/javascript">
 //requirejs(['../scrollMonitor'], function( scrollMonitor ) {

--- a/demos/stress.html
+++ b/demos/stress.html
@@ -71,7 +71,7 @@
 </div>
 <div id="counter"><div><div id="status">Rendering elements...</div><div id="progress_numbers"></div><progress></progress></div></div>
 <a href="https://github.com/sakabako/scrollMonitor"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
-<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script src="../scrollMonitor.js"></script>
 <script type="text/javascript">
 


### PR DESCRIPTION
Corrected the following error thrown in every demo:

> Mixed Content: The page at 'https://stutrek.github.io/scrollMonitor/demos/stress.html' was loaded over HTTPS, but requested an insecure script 'http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.