### PR TITLE
Removing unnecessary call

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -154,7 +154,6 @@ class ScrollMonitorContainer {
 	DOMListener (event) {
 		//alert('got scroll');
 		this.setStateFromDOM(event);
-		this.updateAndTriggerWatchers(event);
 	}
 
 	setStateFromDOM (event) {


### PR DESCRIPTION
`DOMListener()` calls `setStateFromDOM()` which calls `setState()` which calls `updateAndTriggerWatchers()`.  Since none of these functions can exit early, `updateAndTriggerWatchers()` will always be called by virtue of the `setStateFromDOM()` call and thus doesn't need to be explicitly invoked.