### PR TITLE
Should not set the global variable "scrollMonitor" when in AMD environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,4 @@ var scrollMonitor = new ScrollMonitorContainer(isInBrowser ? document.body : nul
 scrollMonitor.setStateFromDOM(null);
 scrollMonitor.listenToDOM();
 
-if (isInBrowser) {
-	window.scrollMonitor = scrollMonitor;
-}
-
 module.exports = scrollMonitor;


### PR DESCRIPTION
First, thanks for the awesome library. It does its job very well 👍 

---

Just to nitpick, the current implementation defines global variable `window.scrollMonitor` explicitly in [`index.js#L10`](https://github.com/stutrek/scrollMonitor/blob/f88afe9b9b066176778169750f66369390588eb6/index.js#L10):
```js
if (isInBrowser) {
  window.scrollMonitor = scrollMonitor;
}
```
This is somewhat unwanted functionality in AMD environments (especially when one is developing cross-site widgets and want to avoid conflicts with globals on host sites).

As a solution, I propose we get rid of the explicit global `window.scrollMonitor` definition and we let the Webpack Universal Module Definition target template handle it [_as you already use it_](https://github.com/stutrek/scrollMonitor/blob/v1.2.3/webpack.config.js#L9-L11):

```js
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else {
		var a = factory();
		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
	}
})(this, function() {
  // the rest of the webpack bootstrap ...
  // actual scrollMonitor scripts ...
```
Which basically checks if in:
1. CommonJS environment
2. AMD environment
3. Attach to root/global, which in browserland is `window`
… and then initializes the library for the first environment it detects.
