### PR TITLE
WIP: Add typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,59 @@
+declare module 'scrollmonitor' {
+  export const scrollMonitor: ScrollMonitorContainer;
+  export default scrollMonitor;
+
+  export class ScrollMonitorContainer {
+    viewportTop: number;
+    viewportBottom: number;
+    viewportHeight: number;
+    documentHeight: number;
+
+    constructor(containerEl: HTMLElement);
+
+    create: (
+      watchItem: HTMLElement | object | number | NodeList | Array<any> | string,
+      offsets?: Offsets | number
+    ) => Watcher;
+
+    update: () => void;
+    recalculateLocations: () => void;
+
+    createContainer: (containerEl: HTMLElement) => ScrollMonitorContainer;
+  }
+
+  export interface Watcher {
+    isInViewport: boolean;
+    isFullyInViewport: boolean;
+    isAboveViewport: boolean;
+    isBelowViewport: boolean;
+    top: number;
+    bottom: number;
+    height: number;
+    watchItem: HTMLElement | object | number;
+    offsets: Offsets;
+
+    // Events
+    visibilityChange: (callback: () => void) => void;
+    stateChange: (callback: () => void) => void;
+    enterViewport: (callback: () => void) => void;
+    fullyEnterViewport: (callback: () => void) => void;
+    exitViewport: (callback: () => void) => void;
+    partiallyExitViewport: (callback: () => void) => void;
+
+    // Functions
+    on: () => void;
+    off: () => void;
+    one: () => void;
+    recalculateLocation: () => void;
+    destroy: () => void;
+    lock: () => void;
+    unlock: () => void;
+    update: () => void;
+    triggerCallbacks: () => void;
+  }
+
+  export interface Offsets {
+    top?: number;
+    bottom?: number;
+  }
+}


### PR DESCRIPTION
Allows to use the scrollMonitor library in TypeScript projects.

Started using the scrollMonitor library in a typescript project and wrote typings to get it working. Calling this a WIP as long I didn't test all the functions and properties, and also because I never published any typings yet.

Also, I'm not sure this has to go to the maintainers repository or to the typings repository.
There's a [recommendation](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html), but IMHO it doesn't state that one or the other method is a must.