### PR TITLE
fix(container.ts): Check for window undefined error in SSR apps

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -6,8 +6,11 @@ function getViewportHeight(element: HTMLElement) {
     if (isOnServer) {
         return 0;
     }
+    if(typeof window !== 'undefined'){
+        return window.innerHeight;
+    }
     if (element === document.body) {
-        return window.innerHeight || document.documentElement.clientHeight;
+        return document.documentElement.clientHeight;
     } else {
         return element.clientHeight;
     }


### PR DESCRIPTION
On SSR apps specially, those which do not use webpack,

 window is
undefined, REFERENCE ERROR would be thrown

 to avoid reference errors
in SSR apps this check will be helpful

Closes #99